### PR TITLE
feat: add liquibase configuration and table schema for festival

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "java.configuration.updateBuildConfiguration": "interactive"
+    "java.configuration.updateBuildConfiguration": "interactive",
+    "java.compile.nullAnalysis.mode": "automatic"
 }

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -69,6 +69,10 @@
 			<artifactId>datasource-proxy</artifactId>
 			<version>1.10</version>
 		</dependency>
+		<dependency>
+			<groupId>org.liquibase</groupId>
+			<artifactId>liquibase-core</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -13,11 +13,15 @@ spring:
             initialization-fail-timeout: -1
     jpa:
         hibernate:
-            ddl-auto: update
+            ddl-auto: none
         properties:
             hibernate:
                 dialect: org.hibernate.dialect.PostgreSQLDialect
         show-sql: true
+
+    liquibase:
+        enabled: true
+        change-log: classpath:db/changelog/db.changelog-master.yml
 
 logging:
     level:

--- a/api/src/main/resources/db/changelog/001-create-festival-table.yml
+++ b/api/src/main/resources/db/changelog/001-create-festival-table.yml
@@ -1,0 +1,16 @@
+databaseChangeLog:
+  - changeSet:
+      id: 001-create-festival-table
+      author: supzero
+      changes:
+        - createTable:
+            tableName: festival
+            columns:
+              - column: { name: id, type: BIGINT, autoIncrement: true, constraints: { primaryKey: true, nullable: false } }
+              - column: { name: name, type: VARCHAR(255), constraints: { nullable: false } }
+              - column: { name: city, type: VARCHAR(255) }
+              - column: { name: lat, type: "DECIMAL(9,6)" }
+              - column: { name: lng, type: "DECIMAL(9,6)" }
+              - column: { name: start_date, type: DATE }
+              - column: { name: end_date, type: DATE }
+              - column: { name: genre, type: VARCHAR(100) }

--- a/api/src/main/resources/db/changelog/db.changelog-master.yml
+++ b/api/src/main/resources/db/changelog/db.changelog-master.yml
@@ -1,0 +1,3 @@
+databaseChangeLog:
+  - include:
+      file: db/changelog/001-create-festival-table.yml


### PR DESCRIPTION
# Description
Intégrer Liquibase au projet Spring Boot pour gérer les migrations de schéma.
Créer un schéma minimal pour l'entité principale (Festival) aligné avec les besoins du frontend (nom, ville, coordonnées, dates, genre…).

## Type de changement
- [ ] 🐞 Bug fix
- [x] ✨ Nouvelle fonctionnalité
- [ ] ♻️ Refactor
- [ ] 🧹 Chore / maintenance

## Checklist
- [x] Le code est testé
- [x] Le linter passe (ESLint / Checkstyle)
- [x] La CI est verte
- [x] La doc/README est à jour

## Liens
Issue liée : Closes #33
