### PR TITLE
feat: configure CORS for frontend FestMap

### DIFF
--- a/api/src/main/java/com/project/festmap/shared/config/WebConfig.java
+++ b/api/src/main/java/com/project/festmap/shared/config/WebConfig.java
@@ -1,0 +1,24 @@
+package com.project.festmap.shared.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig {
+
+  @Bean
+  public WebMvcConfigurer corsConfigurer() {
+    return new WebMvcConfigurer() {
+      @Override
+      public void addCorsMappings(CorsRegistry registry) {
+        registry
+            .addMapping("/api/**")
+            .allowedOrigins("http://localhost:4200", "https://fest-map-ml.vercel.app")
+            .allowedMethods("GET", "POST", "DELETE", "OPTIONS")
+            .allowedHeaders("Content-Type", "Authorization");
+      }
+    };
+  }
+}


### PR DESCRIPTION
# Description
Configurer CORS dans Spring Boot pour permettre au frontend Angular (port 4200 en dev, déploiement Vercel/Autre en prod) d'appeler l'API.

## Type de changement
- [ ] 🐞 Bug fix
- [x] ✨ Nouvelle fonctionnalité
- [ ] ♻️ Refactor
- [ ] 🧹 Chore / maintenance

## Checklist
- [x] Le code est testé
- [x] Le linter passe (ESLint / Checkstyle)
- [ ] La CI est verte
- [x] La doc/README est à jour

## Liens
Issue liée : Closes #39 
