### PR TITLE
feat: configure jacoco for code coverage reporting

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -44,35 +44,37 @@ L'API sera accessible sur `http://localhost:8080`.
 
 L'API sera accessible sur `http://localhost:8080`.
 
-## Compilation et Tests
+## Qualité du Code et Tests
 
-Pour compiler le projet et exécuter les tests unitaires :
+Ce projet utilise plusieurs plugins Maven pour garantir un haut niveau de qualité de code.
 
-```bash
-cd api
-./mvnw clean install
-```
+### Lancer les tests
 
-Pour exécuter uniquement les tests :
+Pour exécuter les tests unitaires et d'intégration :
 
 ```bash
 cd api
 ./mvnw test
 ```
 
-## Formatage et Linting
+### Cycle de vie complet de vérification
 
-Ce projet adhère aux conventions de code Java standard. Si des plugins spécifiques de formatage ou d'analyse statique (comme Checkstyle ou Spotless) sont configurés dans le `pom.xml`, vous pouvez utiliser les commandes suivantes (à adapter selon les plugins réellement configurés) :
+Pour lancer le cycle de vie complet (tests, rapport de couverture, vérification du style de code et du seuil de couverture), utilisez la commande `verify`. C'est la commande à utiliser en intégration continue.
 
-Pour appliquer le formatage du code :
 ```bash
-./mvnw spotless:apply # Exemple si Spotless est utilisé
+cd api
+./mvnw verify
 ```
 
-Pour vérifier la conformité au style et les règles de linting :
-```bash
-./mvnw checkstyle:check # Exemple si Checkstyle est utilisé
-```
+Cette commande va automatiquement :
+1.  Compiler le code.
+2.  Exécuter tous les tests.
+3.  Analyser la couverture de code avec **JaCoCo**. Le rapport est généré dans `target/site/jacoco/index.html`.
+4.  Vérifier que le seuil de couverture de 70% est atteint.
+5.  Valider le style de code avec **Checkstyle**.
+
+Si l'une de ces étapes échoue, le build sera interrompu.
+
 
 ## Endpoints de l'API
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -28,6 +28,7 @@
 	</scm>
 	<properties>
 		<java.version>21</java.version>
+		<jacoco.version>0.8.12</jacoco.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -161,6 +162,47 @@
 				</executions>
 			</plugin>
 
+			<!-- Couverture de tests -->
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>${jacoco.version}</version>
+				<executions>
+					<execution>
+						<id>prepare-agent</id>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>check</id>
+						<goals>
+							<goal>check</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<rule>
+									<element>BUNDLE</element>
+									<limits>
+										<limit>
+											<counter>INSTRUCTION</counter>
+											<value>COVEREDRATIO</value>
+											<minimum>0.70</minimum>
+										</limit>
+									</limits>
+								</rule>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
# Description
Mettre en place JaCoCo pour générer un rapport de couverture de tests, et une commande dédiée pour la CI.

## Type de changement
- [ ] 🐞 Bug fix
- [x] ✨ Nouvelle fonctionnalité
- [ ] ♻️ Refactor
- [ ] 🧹 Chore / maintenance

## Checklist
- [x] Le code est testé
- [x] Le linter passe (ESLint / Checkstyle)
- [ ] La CI est verte
- [x] La doc/README est à jour

## Liens
Issue liée : Closes #43 
