### PR TITLE
feat(api): add Swagger documentation for API

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ FestMap/
 - Frontend → http://localhost:4200
 - API Health → http://localhost:8080/api/health
 
+## 📖 Documentation API
+La documentation de l'API est générée automatiquement avec **OpenAPI (Swagger)**.
+Elle est interactive et permet de visualiser et tester chaque endpoint.
+
+- **URL d'accès** → http://localhost:8080/swagger-ui.html
+
 ## 🧪 Health check attendu
 
 Succès :

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -79,6 +79,11 @@
 			<artifactId>h2</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.8.14</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -33,3 +33,9 @@ logging:
           core: DEBUG
           JdbcTemplate: DEBUG
           StatementCreatorUtils: TRACE
+springdoc:
+  packages-to-scan:
+    - com.project.festmap.festival.api
+    - com.project.festmap.shared.api
+  swagger-ui:
+    path: /swagger-ui.html


### PR DESCRIPTION
# Description
Mettre en place une documentation API automatique et interactive (Swagger UI) pour visualiser et tester les endpoints FestMap.

## Type de changement
- [ ] 🐞 Bug fix
- [x] ✨ Nouvelle fonctionnalité
- [ ] ♻️ Refactor
- [ ] 🧹 Chore / maintenance

## Checklist
- [x] Le code est testé
- [x] Le linter passe (ESLint / Checkstyle)
- [ ] La CI est verte
- [x] La doc/README est à jour

## Liens
Issue liée : Closes #47 
